### PR TITLE
Type in dependencies[], 

### DIFF
--- a/jekyll_export/jekyll_export.info
+++ b/jekyll_export/jekyll_export.info
@@ -3,4 +3,4 @@ description = A simple exporter to help migrate from Drupal to Jekyll, using Mar
 package = Other
 version = VERSION
 core = 7.x
-dependencies = markdownify
+dependencies[] = markdownify


### PR DESCRIPTION
In the info file, we should use dependencies[], not dependencies, otherwise markdownify will not be enabled.